### PR TITLE
Fix Primefaces build by example

### DIFF
--- a/idp-connector-demo/pom.xml
+++ b/idp-connector-demo/pom.xml
@@ -23,6 +23,15 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.primefaces</groupId>
+        <artifactId>primefaces</artifactId>
+        <version>13.0.17-LTS</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <repositories>
     <repository>
       <snapshots>

--- a/idp-connector-test/pom.xml
+++ b/idp-connector-test/pom.xml
@@ -41,6 +41,15 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.primefaces</groupId>
+        <artifactId>primefaces</artifactId>
+        <version>13.0.17-LTS</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <repositories>
     <repository>
       <snapshots>

--- a/idp-connector/pom.xml
+++ b/idp-connector/pom.xml
@@ -17,6 +17,15 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.primefaces</groupId>
+        <artifactId>primefaces</artifactId>
+        <version>13.0.17-LTS</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <repositories>
     <repository>
       <snapshots>


### PR DESCRIPTION
use next officially available PF version; which is available through maven central
https://mvnrepository.com/artifact/org.primefaces/primefaces?repo=primefaces